### PR TITLE
Fixes bug #19

### DIFF
--- a/lib/delivery.server.js
+++ b/lib/delivery.server.js
@@ -152,7 +152,7 @@ Delivery.prototype.subscribe = function() {
 
   //server sending to client
   this.socket.on('send.success', function(uid){
-    _this.pubSub.publish('receive.success', uid);
+    _this.pubSub.publish('send.success', uid);
     delete _this.sending[uid];
   });
 };

--- a/lib/delivery.server.js
+++ b/lib/delivery.server.js
@@ -120,8 +120,8 @@ Delivery.prototype.connect = function(){
 Delivery.prototype.subscribe = function() {
   var _this = this;
 
-  this.pubSub.subscribe('receive.success',function(file){
-    _this.socket.emit('send.success',file.uid);
+  this.pubSub.subscribe('receive.success',function(uid){
+    _this.socket.emit('send.success',uid);
   });
   
   this.socket.on('receive.start', function(file) {

--- a/lib/delivery.server.js
+++ b/lib/delivery.server.js
@@ -120,8 +120,8 @@ Delivery.prototype.connect = function(){
 Delivery.prototype.subscribe = function() {
   var _this = this;
 
-  this.pubSub.subscribe('receive.success',function(uid){
-    _this.socket.emit('send.success',uid);
+  this.pubSub.subscribe('receive.success',function(file){
+    _this.socket.emit('send.success',file.uid);
   });
   
   this.socket.on('receive.start', function(file) {


### PR DESCRIPTION
First step of fix for #19. Now error message has changed to:

```
Missing error handler on `socket`.
TypeError: path must be a string
    at TypeError (native)
    at Object.fs.open (fs.js:575:11)
    at Object.fs.writeFile (fs.js:1194:6)
    at Array.<anonymous> (C:\Users\Aron\Documents\Programming Projects\Tracker-3\server\video-upload.js:17:12)
    at PubSub.publish (C:\Users\Aron\Documents\Programming Projects\Tracker-3\server\node_modules\delivery\lib\delivery.server.js:27:11)
    at Socket.<anonymous> (C:\Users\Aron\Documents\Programming Projects\Tracker-3\server\node_modules\delivery\lib\delivery.server.js:158:18)
    at emitOne (events.js:90:13)
    at Socket.emit (events.js:182:7)
    at Socket.onevent (C:\Users\Aron\Documents\Programming Projects\Tracker-3\server\node_modules\socket.io\lib\socket.js:335:8)
    at Socket.onpacket (C:\Users\Aron\Documents\Programming Projects\Tracker-3\server\node_modules\socket.io\lib\socket.js:295:12)
```