### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/delivery.server.js
+++ b/lib/delivery.server.js
@@ -1,4 +1,4 @@
-var uuid    = require('node-uuid'),
+var uuid    = require('uuid'),
     mime    = require('mime'),
     fs      = require('fs');
 

--- a/package.json
+++ b/package.json
@@ -1,29 +1,36 @@
 {
-	"name":"delivery",
-	"description":"Bidirectional File Transfers For Node.js via Socket.IO",
-	"author":
-		{
-			"name":"Liam Kaufman",
-			"email":"liam.kaufman@gmail.com",
-			"web":"http://liamkaufman.com"
-		},
-	"version":"0.0.5",
-	"keywords":["file","transfer","push","socket.io","websockets"],
-	"repository":{
-		"type":"git",
-		"url":"https://liamks@github.com/liamks/Delivery.js.git"	
-	},
-	"engines":{
-		"node":">=0.6.0"
-	},
-	"dependencies":{
-		"socket.io":"*",
-		"node-uuid":"1.3.3",
-		"mime":"*"
-	},
-	"licenses":[{
-		"type":"MIT",
-		"url":"http://www.opensource.org/licenses/MIT"
-	}],
-	"main":"index"
+  "name": "delivery",
+  "description": "Bidirectional File Transfers For Node.js via Socket.IO",
+  "author": {
+    "name": "Liam Kaufman",
+    "email": "liam.kaufman@gmail.com",
+    "web": "http://liamkaufman.com"
+  },
+  "version": "0.0.5",
+  "keywords": [
+    "file",
+    "transfer",
+    "push",
+    "socket.io",
+    "websockets"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://liamks@github.com/liamks/Delivery.js.git"
+  },
+  "engines": {
+    "node": ">=0.6.0"
+  },
+  "dependencies": {
+    "mime": "*",
+    "socket.io": "*",
+    "uuid": "^3.0.0"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
+  "main": "index"
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.