### PR TITLE
Switched from mime.lookup to mime.getType from node-mime v2

### DIFF
--- a/lib/delivery.server.js
+++ b/lib/delivery.server.js
@@ -83,7 +83,7 @@ FilePackage.prototype.generatePrefix = function(){
 }
 
 FilePackage.prototype.getMimeType = function(){
-  this.mimeType = mime.lookup(this.path);
+  this.mimeType = mime.getType(this.path);
 };
 
 FilePackage.prototype.generateUId = function(){

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.6.0"
   },
   "dependencies": {
-    "mime": "*",
+    "mime": "^2.0.3",
     "socket.io": "*",
     "uuid": "^3.0.0"
   },


### PR DESCRIPTION
The newest version of node-mime renamed the lookup function to getType