### PR TITLE
Fixing "FileAPI" errors due to MIME knox dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.6.0"
   },
   "dependencies": {
-    "mime": "^2.0.3",
+    "mime": "1.2.11",
     "socket.io": "*",
     "uuid": "^3.0.0"
   },


### PR DESCRIPTION
FileAPI always throws errors due to MIME's "mime.lookup" being invalidated by Knox.
A simple fix is to downgrade the MIME version.